### PR TITLE
Add Built In properties to entity list

### DIFF
--- a/entities.json
+++ b/entities.json
@@ -2646,7 +2646,7 @@
         "builtincolorado.com",
         "builtinla.com",
         "builtinnyc.com",
-        "builtinseatlle.com",
+        "builtinseattle.com",
         "builtinsf.com"
       ],
       "resources": [
@@ -2657,7 +2657,7 @@
         "builtincolorado.com",
         "builtinla.com",
         "builtinnyc.com",
-        "builtinseatlle.com",
+        "builtinseattle.com",
         "builtinsf.com"
       ]
     },

--- a/entities.json
+++ b/entities.json
@@ -2637,6 +2637,30 @@
         "bufferapp.com"
       ]
     },
+    "BuiltIn": {
+      "properties": [
+        "builtin.com",
+        "builtinaustin.com",
+        "builtinboston.com",
+        "builtinchicago.org",
+        "builtincolorado.com",
+        "builtinla.com",
+        "builtinnyc.com",
+        "builtinseatlle.com",
+        "builtinsf.com"
+      ],
+      "resources": [
+        "builtin.com",
+        "builtinaustin.com",
+        "builtinboston.com",
+        "builtinchicago.org",
+        "builtincolorado.com",
+        "builtinla.com",
+        "builtinnyc.com",
+        "builtinseatlle.com",
+        "builtinsf.com"
+      ]
+    },
     "Bunchball": {
       "properties": [
         "bunchball.com"


### PR DESCRIPTION
# What's changing 📝

This adds Built In's properties and resources to the entity list for companies that integrate the disconnect.me lists.  These are used to either aid in cross-domain cookies, or (if found abusive) blocks cross-domain cookies.  Currently, Firefox and Microsoft is using the disconnect.me entities list to allow sites that own multiple properties (domains) to treat their cross-domain cookies as 1st party cookies instead of 3rd party cookies.

## References 📓

https://docs.microsoft.com/en-us/microsoft-edge/web-platform/tracking-prevention#mitigations
https://github.com/mozilla-services/shavar-prod-lists#disconnect-entitylistjson